### PR TITLE
Trim the roll number in middleware to address autofill issues.

### DIFF
--- a/scp/lib/userdata.dart
+++ b/scp/lib/userdata.dart
@@ -86,7 +86,7 @@ class UserdataState extends State<Userdata> {
                                     hintText: 'Enter Roll No.',
                                     border: InputBorder.none),
                                 onChanged: (value) {
-                                  rollNo = value;
+                                  rollNo = value.trim();
                                 },
                                 controller: rollController,
                               ),


### PR DESCRIPTION
When the roll number was autofilled , an extra space was appended which caused a mismatch with the regex despite the string matching it perfectly. User needed to manually press backspace . This was addressed by trimming the roll number before sending for verification.