### PR TITLE
Modified Timetable to automatically display accurate time table for the current Semester

### DIFF
--- a/scp/lib/time_table.dart
+++ b/scp/lib/time_table.dart
@@ -27,19 +27,24 @@ class TimeTableState extends State<TimeTable> {
   double screenWidth, screenHeight;
 
   Future _fetchSectionData(BuildContext context) async {
+    TimeTableResources.setCourseNumber();
     SharedPreferences prefs = await SharedPreferences.getInstance();
     theorySection = prefs.getString('theory_section');
     practicalSection = prefs.getString('prac_section');
+    bool isAutumnSemester = TimeTableResources.isAutumnSemester();
     if ((theorySection.compareTo('Ar.') == 0) ||
         (theorySection.compareTo('A') == 0) ||
         (theorySection.compareTo('D') == 0) ||
         (theorySection.compareTo('C') == 0) ||
         (theorySection.compareTo('B') == 0)) {
-      sectionSequence = 'tp';
+      sectionSequence = isAutumnSemester ? 'tp' :'pt';
+    }else{
+      sectionSequence = isAutumnSemester? 'pt' : 'tp';
     }
-    print("Sequence" + sectionSequence);
-    print("Theory" + theorySection);
-    print("Practical" + practicalSection);
+    if(!isAutumnSemester && theorySection.compareTo('Ar.')!=0){
+      theorySection = TimeTableResources.subsituteTheorySection[theorySection];
+      practicalSection = TimeTableResources.substitutePracticalSection[practicalSection];
+    }
   }
 
   _resetSections(BuildContext context) async {

--- a/scp/lib/time_table_resources.dart
+++ b/scp/lib/time_table_resources.dart
@@ -1,4 +1,18 @@
 abstract class TimeTableResources {
+  static bool isAutumnSemester ()=> DateTime.now().month>6;
+  static String courseNumber = 'I';
+  static void setCourseNumber(){
+    courseNumber = isAutumnSemester() ? 'I' : 'II';
+    theory['A']['TA'] = theory['B']['TA']
+    = theory['C']['TB'] = theory['D']['TB']
+    = theory['E']['TK'] = theory['F']['TK']
+    = theory['G']['TM'] = theory['H']['TM'] = 'Physics-$courseNumber';
+
+    theory['A']['TC'] = theory['B']['TC']
+    = theory['C']['TD'] = theory['D']['TD']
+    = theory['E']['TJ'] = theory['F']['TJ']
+    = theory['G']['TL'] = theory['H']['TL'] = 'Mathematics-$courseNumber';
+  }
   static final tpSequence = {
     'Monday': ['TA', 'TB', 'TC', 'TE', 'PA', 'PA', 'PA', 'TF', 'ZA'],
     'Tuesday': ['TB', 'TC', 'TD', 'TE', 'PB', 'PB', 'PB', 'TF', 'ZB'],
@@ -168,6 +182,30 @@ abstract class TimeTableResources {
     'WP': {'name': 'Workshop Practices', 'location': 'https://www.google.com/maps/search/?api=1&query=22.2526002,84.9029979', 'locationName': 'Central Workshop'},
     'CL': {'name': 'Chemistry Laboratory', 'location': 'https://www.google.com/maps/search/?api=1&query=22.2523901,84.9010777', 'locationName': 'Main Building'},
     'ED': {'name': 'Engineering Drawing', 'location': 'https://www.google.com/maps/search/?api=1&query=22.2513332,84.9048918', 'locationName': 'LA1'},
+  };
+
+  static final subsituteTheorySection = {
+    'A' : 'E',
+    'B' : 'F',
+    'C' : 'G',
+    'D' : 'H',
+    'E' : 'A',
+    'F' : 'B',
+    'G' : 'C',
+    'H' : 'D'
+  };
+
+  static final substitutePracticalSection = {
+    'P1' : 'P6',
+    'P2' : 'P7',
+    'P3' : 'P8',
+    'P4' : 'P9',
+    'P5' : 'P10',
+    'P6' : 'P1',
+    'P7' : 'P2',
+    'P8' : 'P3',
+    'P9' : 'P4',
+    'P10': 'P5'
   };
 }
 


### PR DESCRIPTION
The timetable has been modified to automatically display the accurate one depending upon the current semester. 

Changes made : 

- Check if the current Semester is Autumn Semester.
- If it is Spring semester, internally change the section to the appropriate section(A changes to E,P1 changes to P6)
- Change the course Name of Maths and Physics-I if it is the Spring Semester.
