### PR TITLE
Fixes: App drawer menus and logout button overlapping

### DIFF
--- a/scp/lib/home_page.dart
+++ b/scp/lib/home_page.dart
@@ -61,170 +61,171 @@ class _HomePageState extends State<HomePage> {
           return Scaffold(
             key: _scaffoldKey,
             drawer: Drawer(
-                child: Column(
+                child: SafeArea(
+                  child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
-              mainAxisAlignment: MainAxisAlignment.start,
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: <Widget>[
-                DrawerHeader(
-                  margin: EdgeInsets.all(0),
-                  child: Column(
-                    mainAxisSize: MainAxisSize.max,
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: <Widget>[
-                      Text(
-                        username,
-                        style: TextStyle(
-                            fontSize: SizeConfig.screenWidth * 0.058,
-                            fontFamily: 'PfDin'),
-                      ),
-                      Padding(
-                        padding: const EdgeInsets.only(top: 4.0),
-                        child: Text(
-                          phoneNo,
+                  Padding(
+                    padding: EdgeInsets.only(left: SizeConfig.screenWidth*0.04, top: SizeConfig.screenHeight*0.035),
+                    child: Column(
+                      mainAxisSize: MainAxisSize.max,
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: <Widget>[
+                        Text(
+                          username,
                           style: TextStyle(
-                              fontSize: SizeConfig.screenWidth * 0.035,
+                              fontSize: SizeConfig.screenWidth * 0.058,
                               fontFamily: 'PfDin'),
                         ),
-                      ),
-                      Padding(
-                        padding: const EdgeInsets.only(top: 4.0),
-                        child: Text(
-                          rollNo,
-                          style: TextStyle(
-                              fontSize: SizeConfig.screenWidth * 0.035,
-                              fontFamily: 'PfDin'),
+                        Padding(
+                          padding: const EdgeInsets.only(top: 4.0),
+                          child: Text(
+                            phoneNo,
+                            style: TextStyle(
+                                fontSize: SizeConfig.screenWidth * 0.035,
+                                fontFamily: 'PfDin'),
+                          ),
                         ),
-                      )
-                    ],
+                        Padding(
+                          padding: const EdgeInsets.only(top: 4.0),
+                          child: Text(
+                            rollNo,
+                            style: TextStyle(
+                                fontSize: SizeConfig.screenWidth * 0.035,
+                                fontFamily: 'PfDin'),
+                          ),
+                        )
+                      ],
+                    ),
                   ),
-                ),
-                Expanded(
-                  flex: 8,
-                  child: Column(
-                    mainAxisSize: MainAxisSize.max,
-                    mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                    children: <Widget>[
-                      ListTile(
-                        onTap: () {
-                          Navigator.of(context).pushNamed(Routes.rImpDocs);
-                        },
-                        title: Text(
-                          "Important Documents",
-                          style: TextStyle(
-                              fontSize: SizeConfig.drawerItemTextSize,
-                              fontFamily: 'PfDin'),
+                  SizedBox(
+                    child: Column(
+                      mainAxisSize: MainAxisSize.max,
+                      mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                      children: <Widget>[
+                        ListTile(
+                          onTap: () {
+                            Navigator.of(context).pushNamed(Routes.rImpDocs);
+                          },
+                          title: Text(
+                            "Important Documents",
+                            style: TextStyle(
+                                fontSize: SizeConfig.drawerItemTextSize,
+                                fontFamily: 'PfDin'),
+                          ),
                         ),
-                      ),
-                      ListTile(
-                        onTap: () {
-                          Navigator.pushNamed(context, Routes.rNots);
-                        },
-                        title: Text(
-                          "Notifications",
-                          style: TextStyle(
-                              fontSize: SizeConfig.drawerItemTextSize,
-                              fontFamily: 'PfDin'),
+                        ListTile(
+                          onTap: () {
+                            Navigator.pushNamed(context, Routes.rNots);
+                          },
+                          title: Text(
+                            "Notifications",
+                            style: TextStyle(
+                                fontSize: SizeConfig.drawerItemTextSize,
+                                fontFamily: 'PfDin'),
+                          ),
                         ),
-                      ),
-                      ListTile(
-                        onTap: () {
-                          Navigator.of(context).pushNamed(Routes.rSettings);
-                        },
-                        title: Text(
-                          "Settings",
-                          style: TextStyle(
-                              fontSize: SizeConfig.drawerItemTextSize,
-                              fontFamily: 'PfDin'),
+                        ListTile(
+                          onTap: () {
+                            Navigator.of(context).pushNamed(Routes.rSettings);
+                          },
+                          title: Text(
+                            "Settings",
+                            style: TextStyle(
+                                fontSize: SizeConfig.drawerItemTextSize,
+                                fontFamily: 'PfDin'),
+                          ),
                         ),
-                      ),
-                      ListTile(
-                        onTap: () {
-                          Navigator.pushNamed(context, Routes.rAboutScp);
-                        },
-                        title: Text(
-                          "About ICS",
-                          style: TextStyle(
-                              fontSize: SizeConfig.drawerItemTextSize,
-                              fontFamily: 'PfDin'),
+                        ListTile(
+                          onTap: () {
+                            Navigator.pushNamed(context, Routes.rAboutScp);
+                          },
+                          title: Text(
+                            "About ICS",
+                            style: TextStyle(
+                                fontSize: SizeConfig.drawerItemTextSize,
+                                fontFamily: 'PfDin'),
+                          ),
                         ),
-                      ),
-                      ListTile(
-                        onTap: () {
-                          _launchURL();
-                        },
-                        title: Text(
-                          "Privacy Policy",
-                          style: TextStyle(
-                              fontSize: SizeConfig.drawerItemTextSize,
-                              fontFamily: 'PfDin'),
+                        ListTile(
+                          onTap: () {
+                            _launchURL();
+                          },
+                          title: Text(
+                            "Privacy Policy",
+                            style: TextStyle(
+                                fontSize: SizeConfig.drawerItemTextSize,
+                                fontFamily: 'PfDin'),
+                          ),
                         ),
-                      ),
-                      ListTile(
-                        onTap: () {
-                          Navigator.of(context).pushNamed(Routes.rDevInfo);
-                        },
-                        title: Text(
-                          "Developer Info",
-                          style: TextStyle(
-                              fontSize: SizeConfig.drawerItemTextSize,
-                              fontFamily: 'PfDin'),
+                        ListTile(
+                          onTap: () {
+                            Navigator.of(context).pushNamed(Routes.rDevInfo);
+                          },
+                          title: Text(
+                            "Developer Info",
+                            style: TextStyle(
+                                fontSize: SizeConfig.drawerItemTextSize,
+                                fontFamily: 'PfDin'),
+                          ),
                         ),
-                      ),
-                      ListTile(
-                        onTap: () {
-                          _launchLink('https://ics.nitrkl.ac.in/');
-                        },
-                        title: Text(
-                          "ICS Website",
-                          style: TextStyle(
-                              fontSize: SizeConfig.drawerItemTextSize,
-                              fontFamily: 'PfDin'),
+                        ListTile(
+                          onTap: () {
+                            _launchLink('https://ics.nitrkl.ac.in/');
+                          },
+                          title: Text(
+                            "ICS Website",
+                            style: TextStyle(
+                                fontSize: SizeConfig.drawerItemTextSize,
+                                fontFamily: 'PfDin'),
+                          ),
                         ),
-                      ),
-                      ListTile(
-                        onTap: () {
-                          _launchLink('https://www.youtube.com/c/ICSNITR');
-                        },
-                        title: Text(
-                          "ICS YouTube",
-                          style: TextStyle(
-                              fontSize: SizeConfig.drawerItemTextSize,
-                              fontFamily: 'PfDin'),
+                        ListTile(
+                          onTap: () {
+                            _launchLink('https://www.youtube.com/c/ICSNITR');
+                          },
+                          title: Text(
+                            "ICS YouTube",
+                            style: TextStyle(
+                                fontSize: SizeConfig.drawerItemTextSize,
+                                fontFamily: 'PfDin'),
+                          ),
                         ),
-                      ),
-                    ],
+                      ],
+                    ),
                   ),
-                ),
-                Expanded(
-                  flex: 2,
-                  child: Align(
-                    alignment: Alignment.center,
-                    child: ButtonTheme(
-                      minWidth: SizeConfig.screenWidth * 0.463,
-                      height: SizeConfig.screenWidth * 0.093,
-                      child: ElevatedButton(
-                        onPressed: () {
-                          _removeUserData(context);
-                        },
-                        style: ElevatedButton.styleFrom(
-                          shape: RoundedRectangleBorder(
-                              borderRadius: BorderRadius.circular(8.0)),
-                          primary: Color.fromRGBO(25, 39, 45, 1),
-                        ),
-                        child: Text(
-                          "Log Out",
-                          style: TextStyle(
-                              fontWeight: FontWeight.w400,
-                              fontFamily: 'PfDin',
-                              color: Colors.white,
-                              fontSize: SizeConfig.screenWidth * 0.046),
+                  Padding(
+                    padding: EdgeInsets.only(bottom: SizeConfig.screenHeight*0.04),
+                    child: Align(
+                      alignment: Alignment.center,
+                      child: ButtonTheme(
+                        minWidth: SizeConfig.screenWidth * 0.463,
+                        height: SizeConfig.screenWidth * 0.093,
+                        child: ElevatedButton(
+                          onPressed: () {
+                            _removeUserData(context);
+                          },
+                          style: ElevatedButton.styleFrom(
+                            shape: RoundedRectangleBorder(
+                                borderRadius: BorderRadius.circular(8.0)),
+                            primary: Color.fromRGBO(25, 39, 45, 1),
+                          ),
+                          child: Text(
+                            "Log Out",
+                            style: TextStyle(
+                                fontWeight: FontWeight.w400,
+                                fontFamily: 'PfDin',
+                                color: Colors.white,
+                                fontSize: SizeConfig.screenWidth * 0.046),
+                          ),
                         ),
                       ),
                     ),
-                  ),
-                )
+                  )
               ],
-            )),
+            ),
+                )),
             appBar: AppBar(
               leading: Padding(
                 padding: EdgeInsets.only(top: SizeConfig.screenWidth * 0.037),

--- a/scp/lib/time_table.dart
+++ b/scp/lib/time_table.dart
@@ -1,3 +1,4 @@
+import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/material.dart';
 import 'package:scp/utils/routes.dart';
 import 'package:scp/utils/sizeConfig.dart';
@@ -188,26 +189,41 @@ class TimeTableState extends State<TimeTable> {
                   child: Stack(children: [
                     Align(
                       alignment: Alignment.topLeft,
-                      child: RichText(
-                          text: TextSpan(
-                        children: <TextSpan>[
-                          TextSpan(
-                            text: periodDetail.name + '\n',
-                            style: TextStyle(
+                      child: Column(
+                        mainAxisAlignment: MainAxisAlignment.start,
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Container(
+                            height: 23,
+                            width: screenWidth*0.65,
+                            child: AutoSizeText(
+                              periodDetail.name,
+                              style: TextStyle(
                                 color: Colors.white,
                                 fontSize: 20.0,
-                                fontWeight: FontWeight.w700),
+                                fontWeight: FontWeight.w600,
+                              ),
+                              maxLines: 1,
+                            ),
                           ),
-                          TextSpan(
-                            text: periodDetail.slotTime,
-                            style: TextStyle(
-                              color: Colors.white.withAlpha(200),
-                              fontSize: 16.0,
-                              fontWeight: FontWeight.w600,
+                          SizedBox(
+                            height: 3,
+                          ),
+                          Container(
+                            height: 19.8,
+                            width: screenWidth*0.65,
+                            child: AutoSizeText(
+                              periodDetail.slotTime,
+                              style: TextStyle(
+                                  color: Colors.white.withAlpha(200),
+                                  fontSize: 16.0,
+                                  fontWeight: FontWeight.w600,
+                              ),
+                              maxLines: 1,
                             ),
                           ),
                         ],
-                      )),
+                      ),
                     ),
                     Align(
                       alignment: Alignment.centerRight,
@@ -339,11 +355,39 @@ class TimeTableState extends State<TimeTable> {
                     ),
                     Align(
                       alignment: Alignment.bottomCenter,
-                      child: ElevatedButton(
-                          child: Text('Location'),
-                          onPressed: () {
-                            launchMap(periodDetail.location);
-                          }),
+                      child: SizedBox(
+                        width: screenWidth*0.4,
+                        child: RaisedButton(
+                            color: const Color(0xff1f538d),
+                            shape: RoundedRectangleBorder(
+                              borderRadius: BorderRadius.circular(8),
+                            ),
+                            child: Padding(
+                              padding: EdgeInsets.symmetric(vertical: 8),
+                              child: Row(
+                                mainAxisAlignment: MainAxisAlignment.center,
+                                crossAxisAlignment: CrossAxisAlignment.center,
+                                children: [
+                                  Icon(Icons.navigation_outlined, color: Colors.white,),
+                                  SizedBox(
+                                    width: 3,
+                                  ),
+                                  Text(
+                                      'Location',
+                                    style: TextStyle(
+                                      color: Colors.white,
+                                      fontSize: 18.5,
+                                      fontWeight: FontWeight.w600,
+                                    ),
+                                  ),
+                                ],
+                              ),
+                            ),
+                            onPressed: () {
+                              launchMap(periodDetail.location);
+                            }
+                            ),
+                      ),
                     ),
                   ]),
                 ),

--- a/scp/pubspec.yaml
+++ b/scp/pubspec.yaml
@@ -40,6 +40,7 @@ dependencies:
   pin_code_text_field: ^1.8.0
   rate_my_app: ^1.1.1
   shared_preferences: ^2.0.7
+  auto_size_text: ^3.0.0
   stacked: ^1.7.6
   table_calendar: ^2.2.3
   url_launcher: ^6.0.10


### PR DESCRIPTION
Fixed Issue #257 

- used flexible widgets properly
- aligned column as space between so that the drawer is more flexible 

![fixed_drawermenu](https://user-images.githubusercontent.com/81508078/194412548-92d6cc95-de90-4984-89ba-0ea2f52088d4.jpeg)
